### PR TITLE
Add offline training diagram

### DIFF
--- a/slides/_basic_coupling.qmd
+++ b/slides/_basic_coupling.qmd
@@ -71,6 +71,9 @@ Notes:
 See [TorchScript reference](https://pytorch.org/docs/stable/jit_language_reference.html#language-reference) for feature compatibility.
 :::
 
+## Offline training with FTorch
+
+![](https://cambridge-iccs.github.io/FTorch/page/offline.png){width=50%}
 
 ## Calling from Fortran
 

--- a/slides/_basic_coupling.qmd
+++ b/slides/_basic_coupling.qmd
@@ -73,7 +73,7 @@ See [TorchScript reference](https://pytorch.org/docs/stable/jit_language_referen
 
 ## Offline training with FTorch
 
-![](https://cambridge-iccs.github.io/FTorch/page/offline.png){width=50%}
+![](https://cambridge-iccs.github.io/FTorch/page/offline.png){.absolute top=35% left=20% width=60%}
 
 ## Calling from Fortran
 


### PR DESCRIPTION
This PR adds a slide illustrating the offline training workflow for the simplenet exercise.

I'm a bit stuck because the `{width=50%}` doesn't seem to have any effect? The image is quite large.