### PR TITLE
feat: add pip venv and LD_LIBRARY_PATH to .bashrc

### DIFF
--- a/build_FTorch.sh
+++ b/build_FTorch.sh
@@ -8,6 +8,7 @@
 #   We will specify the cpu-only version of PyTorch to match the codespace hardware
 python3 -m venv .venv
 source .venv/bin/activate
+echo "source $(pwd)/.venv/bin/activate" >> $HOME/.bashrc
 pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install numpy
 
@@ -34,6 +35,11 @@ cmake --build . --target install
 
 # Add LibTorch libraries to the paths to be searched for dynamic linking at runtime
 export LD_LIBRARY_PATH=$PYTHON_PATH/torch/lib
+
+# Add these commands to the .bashrc for future use
+echo "export LD_LIBRARY_PATH=$PYTHON_PATH/torch/lib" >> $HOME/.bashrc
+echo "run the following command to setup your environment:"
+echo "source \$HOME/.bashrc"
 
 # Return user to the root of the workshop, leaving the venv activated
 cd

--- a/build_FTorch.sh
+++ b/build_FTorch.sh
@@ -34,10 +34,10 @@ cmake .. \
 cmake --build . --target install
 
 # Add LibTorch libraries to the paths to be searched for dynamic linking at runtime
-export LD_LIBRARY_PATH=$PYTHON_PATH/torch/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PYTHON_PATH/torch/lib
 
 # Add these commands to the .bashrc for future use
-echo "export LD_LIBRARY_PATH=$PYTHON_PATH/torch/lib" >> $HOME/.bashrc
+echo "export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:$PYTHON_PATH/torch/lib" >> $HOME/.bashrc
 echo "run the following command to setup your environment:"
 echo "source \$HOME/.bashrc"
 


### PR DESCRIPTION
This is necessary because if the codespace session times out, these variables need to be re-sourced. Currently the user has to do it manually or rerun the build script.

There's a couple of places it could go, but I think this is the best considering we will ask the users to run this script at least once. (if they run again they will get duplicate sourcing... but I hope that wont be a big problem)