### PR TITLE
Build script should be sourced

### DIFF
--- a/slides/_preparation.qmd
+++ b/slides/_preparation.qmd
@@ -20,6 +20,13 @@ Note that we have set up the codespace to have a Python virtual environment set 
 activated for you.
 :::
 
+:::{.fragment}
+Execute the following to start the FTorch build process:
+```shell
+source build_FTorch.sh
+```
+:::
+
 ## Exercise 0 -- Hello Fortran and PyTorch!
 
 :::{.fragment}


### PR DESCRIPTION
This isn't mentioned anywhere else in the slides. Note that attendees need to install PyTorch before they can do exercise 0.